### PR TITLE
Feature 20200404

### DIFF
--- a/Cloud.Ocr.sln
+++ b/Cloud.Ocr.sln
@@ -5,11 +5,11 @@ VisualStudioVersion = 16.0.29709.97
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Cloud.Ocr", "Cloud.Ocr", "{8EC095EE-24A4-41F0-B5B7-70304CB2C3AF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cloud.Ocr", "Cloud.Ocr\Cloud.Ocr\Cloud.Ocr.csproj", "{5061E32C-F0B2-43AE-B2A0-15F9ADF0EC47}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cloud.Ocr", "Cloud.Ocr\Cloud.Ocr\Cloud.Ocr.csproj", "{5061E32C-F0B2-43AE-B2A0-15F9ADF0EC47}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cloud.Ocr.Activities", "Cloud.Ocr\Cloud.Ocr.Activities\Cloud.Ocr.Activities.csproj", "{35D41BC9-59FD-4D69-8979-2FD5465157A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cloud.Ocr.Activities", "Cloud.Ocr\Cloud.Ocr.Activities\Cloud.Ocr.Activities.csproj", "{35D41BC9-59FD-4D69-8979-2FD5465157A5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cloud.Ocr.Activities.Design", "Cloud.Ocr\Cloud.Ocr.Activities.Design\Cloud.Ocr.Activities.Design.csproj", "{13DA67E9-DF14-4B9B-B30A-ACA0CE7FE194}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cloud.Ocr.Activities.Design", "Cloud.Ocr\Cloud.Ocr.Activities.Design\Cloud.Ocr.Activities.Design.csproj", "{13DA67E9-DF14-4B9B-B30A-ACA0CE7FE194}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{D55435B8-3272-42B6-B52B-F0DCCBA06C3D}"
 EndProject
@@ -19,6 +19,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "UiPath.Shared.Activities.De
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Shared\UiPath.Shared.Activities.Design\UiPath.Shared.Activities.Design.projitems*{13da67e9-df14-4b9b-b30a-aca0ce7fe194}*SharedItemsImports = 5
+		Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.projitems*{35d41bc9-59fd-4d69-8979-2fd5465157a5}*SharedItemsImports = 5
 		Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.projitems*{4546856d-ea50-45c6-9419-eeeacb5a80aa}*SharedItemsImports = 13
 		Shared\UiPath.Shared.Activities.Design\UiPath.Shared.Activities.Design.projitems*{df9c43f0-add3-4fbf-995e-84b92f9cbf25}*SharedItemsImports = 13
 	EndGlobalSection

--- a/Cloud.Ocr/Cloud.Ocr.Activities.Design/Cloud.Ocr.Activities.Design.csproj
+++ b/Cloud.Ocr/Cloud.Ocr.Activities.Design/Cloud.Ocr.Activities.Design.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Designers\BankCardActivityDesigner.xaml" />
+    <None Remove="Designers\MockOcrClientActivityDesigner.xaml" />
     <None Remove="Designers\OcrScopeDesigner.xaml" />
   </ItemGroup>
   <!-- Package Icon -->
@@ -79,6 +80,9 @@
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Page>
     <Page Include="Designers\BankCardActivityDesigner.xaml">
+      <Generator>XamlIntelliSenseFileGenerator</Generator>
+    </Page>
+    <Page Include="Designers\MockOcrClientActivityDesigner.xaml">
       <Generator>XamlIntelliSenseFileGenerator</Generator>
     </Page>
     <Page Include="Designers\OcrScopeDesigner.xaml">

--- a/Cloud.Ocr/Cloud.Ocr.Activities.Design/DesignerMetadata.cs
+++ b/Cloud.Ocr/Cloud.Ocr.Activities.Design/DesignerMetadata.cs
@@ -28,6 +28,10 @@ namespace Cloud.Ocr.Activities.Design
             builder.AddCustomAttributes(typeof(BankCardActivity), new DesignerAttribute(typeof(BankCardActivityDesigner)));
             builder.AddCustomAttributes(typeof(BankCardActivity), new HelpKeywordAttribute(""));
 
+            builder.AddCustomAttributes(typeof(MockOcrClientActivity), categoryAttribute);
+            builder.AddCustomAttributes(typeof(MockOcrClientActivity), new DesignerAttribute(typeof(MockOcrClientActivityDesigner)));
+            builder.AddCustomAttributes(typeof(MockOcrClientActivity), new HelpKeywordAttribute(""));
+
 
             MetadataStore.AddAttributeTable(builder.CreateTable());
         }

--- a/Cloud.Ocr/Cloud.Ocr.Activities.Design/Designers/MockOcrClientActivityDesigner.xaml
+++ b/Cloud.Ocr/Cloud.Ocr.Activities.Design/Designers/MockOcrClientActivityDesigner.xaml
@@ -1,0 +1,25 @@
+<sap:ActivityDesigner x:Class="Cloud.Ocr.Activities.Design.Designers.MockOcrClientActivityDesigner"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:activity="clr-namespace:Cloud.Ocr.Activities.Properties;assembly=Cloud.Ocr.Activities"
+                      xmlns:sap="clr-namespace:System.Activities.Presentation;assembly=System.Activities.Presentation"
+                      xmlns:sapv="clr-namespace:System.Activities.Presentation.View;assembly=System.Activities.Presentation"
+                      xmlns:sapc="clr-namespace:System.Activities.Presentation.Converters;assembly=System.Activities.Presentation"
+                      xmlns:converters="clr-namespace:UiPath.Shared.Activities.Design.Converters"
+                      xmlns:uip="clr-namespace:UiPath.Shared.Activities.Design.Controls">
+
+    <sap:ActivityDesigner.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="..\Themes\Generic.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <sapc:ArgumentToExpressionConverter x:Key="ArgumentToExpressionConverter" />
+            <converters:ActivityIconConverter x:Key="ActivityIconConverter" />
+        </ResourceDictionary>
+    </sap:ActivityDesigner.Resources>
+
+    <sap:ActivityDesigner.Icon>
+        <DrawingBrush Stretch="Uniform" Drawing="{Binding Path=ModelItem, Converter={StaticResource ActivityIconConverter}, ConverterParameter=pack://application:\,\,\,/Cloud.Ocr.Activities.Design;component/themes/icons.xaml}" />
+    </sap:ActivityDesigner.Icon>
+
+</sap:ActivityDesigner>

--- a/Cloud.Ocr/Cloud.Ocr.Activities.Design/Designers/MockOcrClientActivityDesigner.xaml.cs
+++ b/Cloud.Ocr/Cloud.Ocr.Activities.Design/Designers/MockOcrClientActivityDesigner.xaml.cs
@@ -1,0 +1,13 @@
+namespace Cloud.Ocr.Activities.Design.Designers
+{
+    /// <summary>
+    /// Interaction logic for MockOcrActivityDesigner.xaml
+    /// </summary>
+    public partial class MockOcrClientActivityDesigner
+    {
+        public MockOcrClientActivityDesigner()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Cloud.Ocr/Cloud.Ocr.Activities.Design/Designers/OcrScopeDesigner.xaml
+++ b/Cloud.Ocr/Cloud.Ocr.Activities.Design/Designers/OcrScopeDesigner.xaml
@@ -23,16 +23,23 @@
     </sap:ActivityDesigner.Icon>
  
     <uip:ActivityDecoratorControl Style="{StaticResource ActivityDecoratorStyle}">
-        <DockPanel LastChildFill="True">
+        <StackPanel>
             <sap:WorkflowItemPresenter x:Uid="sad:WorkflowItemPresenter_1"
-                                       AutomationProperties.AutomationId="Activity"
-                                       DockPanel.Dock="Bottom"
+                                       AutomationProperties.AutomationId="ClientActivity"
                                        MinWidth="400"
-                                       Margin="0,10,0,0"
+                                       Margin="0,10"
+                                       Item="{Binding Path=ModelItem.OcrClient.Handler, Mode=TwoWay}"
+                                       AllowedItemType="{x:Type sa:Activity}"
+                                       HintText="{x:Static p:Resources.DropActivityHere}" />
+            <Separator/>
+            <sap:WorkflowItemPresenter x:Uid="sad:WorkflowItemPresenter_2"
+                                       AutomationProperties.AutomationId="ActionsActivity"
+                                       MinWidth="400"
+                                       Margin="0,10"
                                        Item="{Binding Path=ModelItem.Body.Handler, Mode=TwoWay}"
                                        AllowedItemType="{x:Type sa:Activity}"
                                        HintText="{x:Static p:Resources.DropActivityHere}" />
 
-        </DockPanel>
+        </StackPanel>
     </uip:ActivityDecoratorControl>
 </sap:ActivityDesigner>

--- a/Cloud.Ocr/Cloud.Ocr.Activities/Activities/BankCardActivity.cs
+++ b/Cloud.Ocr/Cloud.Ocr.Activities/Activities/BankCardActivity.cs
@@ -3,6 +3,7 @@ using System.Activities;
 using System.Threading;
 using System.Threading.Tasks;
 using Cloud.Ocr.Activities.Properties;
+using Cloud.Ocr.Contracts;
 using Cloud.Ocr.Models;
 using UiPath.Shared.Activities;
 using UiPath.Shared.Activities.Localization;

--- a/Cloud.Ocr/Cloud.Ocr.Activities/Activities/BaseOcrActivity.cs
+++ b/Cloud.Ocr/Cloud.Ocr.Activities/Activities/BaseOcrActivity.cs
@@ -73,7 +73,8 @@ namespace Cloud.Ocr.Activities
             var result = await ocrClient.RecognizeAsync(recognizerName, imagepath);
 
             // Outputs
-            return (ctx) => {
+            return (ctx) =>
+            {
                 Result.Set(ctx, result);
             };
         }

--- a/Cloud.Ocr/Cloud.Ocr.Activities/Activities/MockOcrClientActivity.cs
+++ b/Cloud.Ocr/Cloud.Ocr.Activities/Activities/MockOcrClientActivity.cs
@@ -13,54 +13,12 @@ namespace Cloud.Ocr.Activities
 {
     [LocalizedDisplayName(nameof(Resources.MockOcrClientActivity_DisplayName))]
     [LocalizedDescription(nameof(Resources.MockOcrClientActivity_Description))]
-    public class MockOcrClientActivity : ContinuableAsyncCodeActivity
+    public class MockOcrClientActivity : BaseOcrClientActivity
     {
-        #region Properties
-
-        /// <summary>
-        /// If set, continue executing the remaining activities even if the current activity has failed.
-        /// </summary>
-        [LocalizedCategory(nameof(Resources.Common_Category))]
-        [LocalizedDisplayName(nameof(Resources.ContinueOnError_DisplayName))]
-        [LocalizedDescription(nameof(Resources.ContinueOnError_Description))]
-        public override InArgument<bool> ContinueOnError { get; set; }
-
-        #endregion
-
-
-        #region Constructors
-
-        public MockOcrClientActivity()
+        protected override IOcrClient GetOcrClient()
         {
+            return new MockOcrClient();
         }
-
-        #endregion
-
-
-        #region Protected Methods
-
-        protected override void CacheMetadata(CodeActivityMetadata metadata)
-        {
-
-            base.CacheMetadata(metadata);
-        }
-
-        protected override async Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
-        {
-            // Inputs
-            IOcrClient ocrClient = new MockOcrClient();
-            var objectContainer = context.GetFromContext<IObjectContainer>(OcrScope.ParentContainerPropertyTag);
-            objectContainer.Add(ocrClient);
-
-            ///////////////////////////
-            // Add execution logic HERE
-            ///////////////////////////
-
-            // Outputs
-            return (ctx) => { };
-        }
-
-        #endregion
     }
 }
 

--- a/Cloud.Ocr/Cloud.Ocr.Activities/Activities/MockOcrClientActivity.cs
+++ b/Cloud.Ocr/Cloud.Ocr.Activities/Activities/MockOcrClientActivity.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Activities;
+using System.Threading;
+using System.Threading.Tasks;
+using Cloud.Ocr.Activities.Properties;
+using Cloud.Ocr.Contracts;
+using Cloud.Ocr.Models;
+using UiPath.Shared.Activities;
+using UiPath.Shared.Activities.Localization;
+using UiPath.Shared.Activities.Utilities;
+
+namespace Cloud.Ocr.Activities
+{
+    [LocalizedDisplayName(nameof(Resources.MockOcrClientActivity_DisplayName))]
+    [LocalizedDescription(nameof(Resources.MockOcrClientActivity_Description))]
+    public class MockOcrClientActivity : ContinuableAsyncCodeActivity
+    {
+        #region Properties
+
+        /// <summary>
+        /// If set, continue executing the remaining activities even if the current activity has failed.
+        /// </summary>
+        [LocalizedCategory(nameof(Resources.Common_Category))]
+        [LocalizedDisplayName(nameof(Resources.ContinueOnError_DisplayName))]
+        [LocalizedDescription(nameof(Resources.ContinueOnError_Description))]
+        public override InArgument<bool> ContinueOnError { get; set; }
+
+        #endregion
+
+
+        #region Constructors
+
+        public MockOcrClientActivity()
+        {
+        }
+
+        #endregion
+
+
+        #region Protected Methods
+
+        protected override void CacheMetadata(CodeActivityMetadata metadata)
+        {
+
+            base.CacheMetadata(metadata);
+        }
+
+        protected override async Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
+        {
+            // Inputs
+            IOcrClient ocrClient = new MockOcrClient();
+            var objectContainer = context.GetFromContext<IObjectContainer>(OcrScope.ParentContainerPropertyTag);
+            objectContainer.Add(ocrClient);
+
+            ///////////////////////////
+            // Add execution logic HERE
+            ///////////////////////////
+
+            // Outputs
+            return (ctx) => { };
+        }
+
+        #endregion
+    }
+}
+

--- a/Cloud.Ocr/Cloud.Ocr.Activities/Cloud.Ocr.Activities.csproj
+++ b/Cloud.Ocr/Cloud.Ocr.Activities/Cloud.Ocr.Activities.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
 		<RootNamespace>Cloud.Ocr.Activities</RootNamespace>

--- a/Cloud.Ocr/Cloud.Ocr.Activities/Contracts/BaseOcrActivity.cs
+++ b/Cloud.Ocr/Cloud.Ocr.Activities/Contracts/BaseOcrActivity.cs
@@ -1,4 +1,5 @@
-﻿using Cloud.Ocr.Activities.Properties;
+﻿using Cloud.Ocr.Activities;
+using Cloud.Ocr.Activities.Properties;
 using Cloud.Ocr.Contracts;
 using Cloud.Ocr.Models;
 using Newtonsoft.Json.Linq;
@@ -13,7 +14,7 @@ using UiPath.Shared.Activities;
 using UiPath.Shared.Activities.Localization;
 using UiPath.Shared.Activities.Utilities;
 
-namespace Cloud.Ocr.Activities
+namespace Cloud.Ocr.Contracts
 {
     public abstract class BaseOcrActivity : ContinuableAsyncCodeActivity
     {

--- a/Cloud.Ocr/Cloud.Ocr.Activities/Contracts/BaseOcrClientActivity.cs
+++ b/Cloud.Ocr/Cloud.Ocr.Activities/Contracts/BaseOcrClientActivity.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Activities;
+using System.Threading;
+using System.Threading.Tasks;
+using Cloud.Ocr.Activities.Properties;
+using Cloud.Ocr.Contracts;
+using Cloud.Ocr.Models;
+using UiPath.Shared.Activities;
+using UiPath.Shared.Activities.Localization;
+using UiPath.Shared.Activities.Utilities;
+
+namespace Cloud.Ocr.Activities
+{
+    public abstract class BaseOcrClientActivity : ContinuableAsyncCodeActivity
+    {
+        #region Properties
+
+        /// <summary>
+        /// If set, continue executing the remaining activities even if the current activity has failed.
+        /// </summary>
+        [LocalizedCategory(nameof(Resources.Common_Category))]
+        [LocalizedDisplayName(nameof(Resources.ContinueOnError_DisplayName))]
+        [LocalizedDescription(nameof(Resources.ContinueOnError_Description))]
+        public override InArgument<bool> ContinueOnError { get; set; }
+
+        #endregion
+
+
+        #region Constructors
+
+        public BaseOcrClientActivity()
+        {
+        }
+
+        #endregion
+
+
+        #region Protected Methods
+
+        protected override void CacheMetadata(CodeActivityMetadata metadata)
+        {
+
+            base.CacheMetadata(metadata);
+        }
+
+        protected abstract IOcrClient GetOcrClient();
+
+        protected override async Task<Action<AsyncCodeActivityContext>> ExecuteAsync(AsyncCodeActivityContext context, CancellationToken cancellationToken)
+        {
+            // Inputs
+            IOcrClient ocrClient = GetOcrClient();
+            var objectContainer = context.GetFromContext<IObjectContainer>(OcrScope.ParentContainerPropertyTag);
+            objectContainer.Add(ocrClient);
+
+            ///////////////////////////
+            // Add execution logic HERE
+            ///////////////////////////
+
+            // Outputs
+            return (ctx) => { };
+        }
+
+        #endregion
+    }
+}
+

--- a/Cloud.Ocr/Cloud.Ocr.Activities/Properties/Resources.Designer.cs
+++ b/Cloud.Ocr/Cloud.Ocr.Activities/Properties/Resources.Designer.cs
@@ -169,6 +169,24 @@ namespace Cloud.Ocr.Activities.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Injects MockOcrClient as IOcrClient in ObjectContainer..
+        /// </summary>
+        public static string MockOcrClientActivity_Description {
+            get {
+                return ResourceManager.GetString("MockOcrClientActivity_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mock OCR.
+        /// </summary>
+        public static string MockOcrClientActivity_DisplayName {
+            get {
+                return ResourceManager.GetString("MockOcrClientActivity_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Contains and authenticates all Ccint OCR activities..
         /// </summary>
         public static string OcrScope_Description {

--- a/Cloud.Ocr/Cloud.Ocr.Activities/Properties/Resources.resx
+++ b/Cloud.Ocr/Cloud.Ocr.Activities/Properties/Resources.resx
@@ -205,4 +205,12 @@
     <value>Returns the recognized values of a bank card.</value>
     <comment>activity description</comment>
   </data>
+  <data name="MockOcrClientActivity_DisplayName" xml:space="preserve">
+    <value>Mock OCR</value>
+    <comment>activity name</comment>
+  </data>
+  <data name="MockOcrClientActivity_Description" xml:space="preserve">
+    <value>Injects MockOcrClient as IOcrClient in ObjectContainer.</value>
+    <comment>activity description</comment>
+  </data>
 </root>

--- a/tests/CloudOcrBasicTests/Tests_Repository/UnitTests/BankCard_ImageExists_ResultReturned.xaml
+++ b/tests/CloudOcrBasicTests/Tests_Repository/UnitTests/BankCard_ImageExists_ResultReturned.xaml
@@ -1,4 +1,4 @@
-<Activity mc:Ignorable="sap sap2010" x:Class="UnitTests" mva:VisualBasic.Settings="{x:Null}" sap:VirtualizedContainerService.HintSize="538,1924" sap2010:WorkflowViewState.IdRef="ParsingTest_1" xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities" xmlns:coa="clr-namespace:Cloud.Ocr.Activities;assembly=Cloud.Ocr.Activities" xmlns:cv="clr-namespace:CustomActivities.VariableComparer;assembly=CustomActivities.VariableComparer" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mva="clr-namespace:Microsoft.VisualBasic.Activities;assembly=System.Activities" xmlns:njl="clr-namespace:Newtonsoft.Json.Linq;assembly=Newtonsoft.Json" xmlns:sap="http://schemas.microsoft.com/netfx/2009/xaml/activities/presentation" xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation" xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib" xmlns:sd="clr-namespace:System.Data;assembly=System.Data" xmlns:usa="clr-namespace:UiPath.Shared.Activities;assembly=Cloud.Ocr.Activities" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<Activity mc:Ignorable="sap sap2010" x:Class="UnitTests" mva:VisualBasic.Settings="{x:Null}" sap:VirtualizedContainerService.HintSize="538,2022" sap2010:WorkflowViewState.IdRef="ParsingTest_1" xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities" xmlns:coa="clr-namespace:Cloud.Ocr.Activities;assembly=Cloud.Ocr.Activities" xmlns:cv="clr-namespace:CustomActivities.VariableComparer;assembly=CustomActivities.VariableComparer" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mva="clr-namespace:Microsoft.VisualBasic.Activities;assembly=System.Activities" xmlns:njl="clr-namespace:Newtonsoft.Json.Linq;assembly=Newtonsoft.Json" xmlns:sap="http://schemas.microsoft.com/netfx/2009/xaml/activities/presentation" xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation" xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib" xmlns:sd="clr-namespace:System.Data;assembly=System.Data" xmlns:usa="clr-namespace:UiPath.Shared.Activities;assembly=Cloud.Ocr.Activities" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <TextExpression.NamespacesForImplementation>
     <scg:List x:TypeArguments="x:String" Capacity="25">
       <x:String>System.Activities</x:String>
@@ -53,7 +53,7 @@
       <AssemblyReference>UiPath.Mail</AssemblyReference>
     </scg:List>
   </TextExpression.ReferencesForImplementation>
-  <Sequence sap2010:Annotation.AnnotationText="Unit testing comprises of three stages: &#xA;&#xA;       - Arrange&#xA;       - Act&#xA;       - Assert. &#xA;&#xA;Basic idea of Unit Testing is to arrange a set of data that will be used to test the code. Using that data, tested code is run and the result is assigned to the &quot;actual&quot; variable. Result of the test run is then asserted to see if test have passed or not (usually this is done by comparing &quot;actual&quot; value with the &quot;expected&quot;).&#xA;&#xA;Tests can be constructed to test &quot;happy&quot; paths, fail paths and/or to check if the correct exceptions are thrown by the code.&#xA;&#xA;It is recommended to make more than one test for each peace of the code. This is to make sure that the code correctly handles both good and bad data, and also to see if correct exceptions are thrown by the code.&#xA;&#xA;IMPORTANT: For Unit Test to be eligible for use in TestingFramework it must implement Assert Unit Test activity that can be found in CustomActivities.VariableComparer namespace." DisplayName="Unit Test" sap:VirtualizedContainerService.HintSize="518,1824" sap2010:WorkflowViewState.IdRef="Sequence_1">
+  <Sequence sap2010:Annotation.AnnotationText="Unit testing comprises of three stages: &#xA;&#xA;       - Arrange&#xA;       - Act&#xA;       - Assert. &#xA;&#xA;Basic idea of Unit Testing is to arrange a set of data that will be used to test the code. Using that data, tested code is run and the result is assigned to the &quot;actual&quot; variable. Result of the test run is then asserted to see if test have passed or not (usually this is done by comparing &quot;actual&quot; value with the &quot;expected&quot;).&#xA;&#xA;Tests can be constructed to test &quot;happy&quot; paths, fail paths and/or to check if the correct exceptions are thrown by the code.&#xA;&#xA;It is recommended to make more than one test for each peace of the code. This is to make sure that the code correctly handles both good and bad data, and also to see if correct exceptions are thrown by the code.&#xA;&#xA;IMPORTANT: For Unit Test to be eligible for use in TestingFramework it must implement Assert Unit Test activity that can be found in CustomActivities.VariableComparer namespace." DisplayName="Unit Test" sap:VirtualizedContainerService.HintSize="518,1922" sap2010:WorkflowViewState.IdRef="Sequence_1">
     <Sequence.Variables>
       <Variable x:TypeArguments="x:String" Name="expected" />
       <Variable x:TypeArguments="x:String" Name="actual" />
@@ -83,7 +83,7 @@
         </Assign.Value>
       </Assign>
     </Sequence>
-    <Sequence sap2010:Annotation.AnnotationText="Purpose of act stage is to run the code that is being tested (by invoking the code and supplying required arguments). &#xA;&#xA;Output of this stage should be actual result that code produces assigned to the &quot;actual&quot; variable." DisplayName="Act" sap:VirtualizedContainerService.HintSize="476,484" sap2010:WorkflowViewState.IdRef="Sequence_5">
+    <Sequence sap2010:Annotation.AnnotationText="Purpose of act stage is to run the code that is being tested (by invoking the code and supplying required arguments). &#xA;&#xA;Output of this stage should be actual result that code produces assigned to the &quot;actual&quot; variable." DisplayName="Act" sap:VirtualizedContainerService.HintSize="476,582" sap2010:WorkflowViewState.IdRef="Sequence_5">
       <sap:WorkflowViewStateService.ViewState>
         <scg:Dictionary x:TypeArguments="x:String, x:Object">
           <x:Boolean x:Key="IsExpanded">True</x:Boolean>
@@ -91,7 +91,7 @@
           <x:Boolean x:Key="IsPinned">False</x:Boolean>
         </scg:Dictionary>
       </sap:WorkflowViewStateService.ViewState>
-      <coa:OcrScope ContinueOnError="{x:Null}" DisplayName="OCR Scope" sap:VirtualizedContainerService.HintSize="434,300" sap2010:WorkflowViewState.IdRef="OcrScope_1">
+      <coa:OcrScope ContinueOnError="{x:Null}" DisplayName="OCR Scope" sap:VirtualizedContainerService.HintSize="434,398" sap2010:WorkflowViewState.IdRef="OcrScope_1">
         <coa:OcrScope.Body>
           <ActivityAction x:TypeArguments="usa:IObjectContainer">
             <ActivityAction.Argument>
@@ -119,6 +119,14 @@
             </Sequence>
           </ActivityAction>
         </coa:OcrScope.Body>
+        <coa:OcrScope.OcrClient>
+          <ActivityAction x:TypeArguments="usa:IObjectContainer">
+            <ActivityAction.Argument>
+              <DelegateInArgument x:TypeArguments="usa:IObjectContainer" Name="OcrScope" />
+            </ActivityAction.Argument>
+            <coa:MockOcrClientActivity ContinueOnError="{x:Null}" DisplayName="Mock OCR" sap:VirtualizedContainerService.HintSize="200,22" sap2010:WorkflowViewState.IdRef="MockOcrClientActivity_1" />
+          </ActivityAction>
+        </coa:OcrScope.OcrClient>
       </coa:OcrScope>
     </Sequence>
     <Sequence sap2010:Annotation.AnnotationText="Purpose of the assert stage is to determine if test have passed or not. &#xA;&#xA;Here we use custom activity called Assert Unit Tests (make sure that you have installed package Custom.Activities.VariableComparer)&#xA;&#xA;NOTE: Recommended way to use Assert Unit Test activity is to use Assert methods like Assert.IsNotNull(actual) or Assert.AreEqual(expected,actual).&#xA;&#xA;NOTE (Not recommended): It is also possible to enter any boolean expression. In this case if entered expression returns as false only generic message will be logged in TestingFramework logs. This can be useful if some custom comparison is needed that is not available as a method of Assert class." DisplayName="Assert" sap:VirtualizedContainerService.HintSize="476,544" sap2010:WorkflowViewState.IdRef="Sequence_6">

--- a/tests/CloudOcrBasicTests/project.json
+++ b/tests/CloudOcrBasicTests/project.json
@@ -3,7 +3,7 @@
   "description": "Basic tests for Cloud OCR Activities Pack",
   "main": "RunAllTests.xaml",
   "dependencies": {
-    "Cloud.Ocr.Activities": "[0.1.0.403134925]",
+    "Cloud.Ocr.Activities": "[0.1.0.405115231]",
     "Custom.Activities.VariableComparer": "[2.1.6]",
     "TestingFrameworkUi": "[1.3.3]",
     "UiPath.Excel.Activities": "[2.5.2]",

--- a/tests/CloudOcrBasicTests/project.json
+++ b/tests/CloudOcrBasicTests/project.json
@@ -3,7 +3,7 @@
   "description": "Basic tests for Cloud OCR Activities Pack",
   "main": "RunAllTests.xaml",
   "dependencies": {
-    "Cloud.Ocr.Activities": "[0.1.0.405115231]",
+    "Cloud.Ocr.Activities": "[0.1.0.405120831]",
     "Custom.Activities.VariableComparer": "[2.1.6]",
     "TestingFrameworkUi": "[1.3.3]",
     "UiPath.Excel.Activities": "[2.5.2]",


### PR DESCRIPTION
Create BaseOcrClientActivity for abstraction of IOcrClient injection. From now on, OcrScope as well as specific OCR activities like BankCardActivity will be OCR client agnostic. This gives the users the flexibility to use different OCR services with the same set of activities.