### PR TITLE
Refactor the scheduling code for children of OcrScope.

### DIFF
--- a/Cloud.Ocr/Cloud.Ocr.Activities.Design/Designers/OcrScopeDesigner.xaml
+++ b/Cloud.Ocr/Cloud.Ocr.Activities.Design/Designers/OcrScopeDesigner.xaml
@@ -28,7 +28,7 @@
                                        AutomationProperties.AutomationId="ClientActivity"
                                        MinWidth="400"
                                        Margin="0,10"
-                                       Item="{Binding Path=ModelItem.OcrClient.Handler, Mode=TwoWay}"
+                                       Item="{Binding Path=ModelItem.Head, Mode=TwoWay}"
                                        AllowedItemType="{x:Type sa:Activity}"
                                        HintText="{x:Static p:Resources.DropActivityHere}" />
             <Separator/>
@@ -36,7 +36,7 @@
                                        AutomationProperties.AutomationId="ActionsActivity"
                                        MinWidth="400"
                                        Margin="0,10"
-                                       Item="{Binding Path=ModelItem.Body.Handler, Mode=TwoWay}"
+                                       Item="{Binding Path=ModelItem.Body, Mode=TwoWay}"
                                        AllowedItemType="{x:Type sa:Activity}"
                                        HintText="{x:Static p:Resources.DropActivityHere}" />
 


### PR DESCRIPTION
Instead of using two ActivityAction and calling ScheduleAction twice separately, the code is refactored to call ScheduleAction once on a Sequence composed with two activities. This helps maintain the execution order.